### PR TITLE
WEEK-9: remove runtime-versions from buildspec.yml, docker should be …

### DIFF
--- a/backend-flask/buildspec.yml
+++ b/backend-flask/buildspec.yml
@@ -2,8 +2,6 @@
 version: 0.2
 phases:
   install:
-    runtime-versions:
-      docker: 20
     commands:
       - echo "cd into $CODEBUILD_SRC_DIR/backend"
       - cd $CODEBUILD_SRC_DIR/backend-flask


### PR DESCRIPTION
…used when "privileged" is enabled under Environment section in CodeBuild project